### PR TITLE
Allow Pipeless Steam Vent to connect to pipes.

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -36,44 +36,44 @@
 dependencies {
     api("com.github.GTNewHorizons:StructureLib:1.4.6:dev")
     api("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    api("com.github.GTNewHorizons:NotEnoughItems:2.7.34-GTNH:dev")
+    api("com.github.GTNewHorizons:NotEnoughItems:2.7.38-GTNH:dev")
     api("com.github.GTNewHorizons:NotEnoughIds:2.1.6:dev")
-    api("com.github.GTNewHorizons:GTNHLib:0.6.17:dev")
+    api("com.github.GTNewHorizons:GTNHLib:0.6.19:dev")
     api("com.github.GTNewHorizons:ModularUI:1.2.18:dev")
     api("com.github.GTNewHorizons:ModularUI2:2.2.6-1.7.10:dev")
     api("com.github.GTNewHorizons:waila:1.8.4:dev")
-    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-563-GTNH:dev")
-    api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.36-gtnh:dev")
+    api("com.github.GTNewHorizons:Applied-Energistics-2-Unofficial:rv3-beta-580-GTNH:dev")
+    api("com.github.GTNewHorizons:AE2FluidCraft-Rework:1.4.46-gtnh:dev")
     api('com.github.GTNewHorizons:Yamcl:0.7.0:dev')
     api("com.github.GTNewHorizons:Postea:1.0.13:dev")
 
-    compileOnlyApi('com.github.GTNewHorizons:ThaumicTinkerer:2.11.7:dev')
+    compileOnlyApi('com.github.GTNewHorizons:ThaumicTinkerer:2.11.8:dev')
     compileOnlyApi("com.github.GTNewHorizons:Mobs-Info:0.5.2-GTNH:dev")
     compileOnlyApi("com.github.GTNewHorizons:Navigator:1.0.15:dev")
     implementation('com.github.GTNewHorizons:Baubles:1.0.4:dev') {transitive=false}
     // Required to prevent an older bauble api from Extra Utilities from loading first in the javac classpath
     compileOnly('com.github.GTNewHorizons:Baubles:1.0.4:dev') {transitive=false}
 
-    devOnlyNonPublishable("com.github.GTNewHorizons:Infernal-Mobs:1.10.0-GTNH:dev")
+    devOnlyNonPublishable("com.github.GTNewHorizons:Infernal-Mobs:1.10.2-GTNH:dev")
 
-    compileOnlyApi("com.github.GTNewHorizons:Avaritia:1.61:dev")
+    compileOnlyApi("com.github.GTNewHorizons:Avaritia:1.62:dev")
 
     compileOnlyApi('com.github.GTNewHorizons:Angelica:1.0.0-beta40:api') { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:AppleCore:3.3.4:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:BuildCraft:7.1.42:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.9.6:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:EnderIO:2.9.7:dev") { transitive = false }
     compileOnlyApi("com.github.GTNewHorizons:ForestryMC:4.10.5:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.11.1-GTNH:dev") { transitive = false }
-    compileOnlyApi("com.github.GTNewHorizons:Railcraft:9.16.7:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:ProjectRed:4.11.3-GTNH:dev") { transitive = false }
+    compileOnlyApi("com.github.GTNewHorizons:Railcraft:9.16.11:dev") { transitive = false }
 
     compileOnly("TGregworks:TGregworks:1.7.10-GTNH-1.0.27:deobf") {transitive = false}
-    compileOnly("com.github.GTNewHorizons:ThaumicBases:1.8.3:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:ThaumicBases:1.8.7:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:EnderCore:0.4.6:dev") { transitive = false }
     compileOnly('com.github.GTNewHorizons:VisualProspecting:1.4.2:dev') { transitive = false }
-    compileOnly("com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.109-GTNH:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:Galaxy-Space-GTNH:1.1.111-GTNH:dev") { transitive = false }
 
     compileOnlyApi("com.github.GTNewHorizons:Galacticraft:3.3.5-GTNH:dev") { transitive = false }
-    implementation("com.github.GTNewHorizons:TinkersConstruct:1.13.13-GTNH:dev")
+    implementation("com.github.GTNewHorizons:TinkersConstruct:1.13.18-GTNH:dev")
 
     compileOnly("com.github.GTNewHorizons:Chisel:2.16.2-GTNH:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:Translocators:1.3.0:dev") { transitive = false }
@@ -85,19 +85,19 @@ dependencies {
     compileOnly('com.github.GTNewHorizons:HoloInventory:2.5.1-GTNH:dev') { transitive = false }
     compileOnly rfg.deobf("curse.maven:extra-utilities-225561:2264384")
     compileOnly rfg.deobf('curse.maven:minefactory-reloaded-66672:2366150')
-    compileOnly("com.github.GTNewHorizons:OpenComputers:1.11.12-GTNH:dev") {transitive = false}
+    compileOnly("com.github.GTNewHorizons:OpenComputers:1.11.13-GTNH:dev") {transitive = false}
     // https://www.curseforge.com/minecraft/mc-mods/advancedsolarpanels
     compileOnlyApi rfg.deobf('curse.maven:advsolar-362768:2885953')
     compileOnly('com.github.GTNewHorizons:ThaumicEnergistics:1.7.6-GTNH:dev') {transitive =  false}
-    compileOnly("com.github.GTNewHorizons:BloodMagic:1.7.5:dev") { transitive = false }
-    compileOnly("com.github.GTNewHorizons:CraftTweaker:3.4.0:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:BloodMagic:1.7.8:dev") { transitive = false }
+    compileOnly("com.github.GTNewHorizons:CraftTweaker:3.4.1:dev") { transitive = false }
     compileOnly("com.github.GTNewHorizons:BetterLoadingScreen:1.7.0-GTNH:dev") { transitive = false }
     compileOnly rfg.deobf("curse.maven:biomes-o-plenty-220318:2499612")
 
     compileOnly('com.github.GTNewHorizons:SC2:2.3.0:dev') {transitive=false}
-    compileOnly('com.github.GTNewHorizons:Binnie:2.5.4:dev') {transitive = false}
+    compileOnly('com.github.GTNewHorizons:Binnie:2.5.7:dev') {transitive = false}
     compileOnly('curse.maven:PlayerAPI-228969:2248928') {transitive=false}
-    devOnlyNonPublishable('com.github.GTNewHorizons:BlockRenderer6343:1.3.2:dev'){transitive=false}
+    devOnlyNonPublishable('com.github.GTNewHorizons:BlockRenderer6343:1.3.9:dev'){transitive=false}
 
     compileOnly("com.google.auto.value:auto-value-annotations:1.10.1") { transitive = false }
     annotationProcessor("com.google.auto.value:auto-value:1.10.1")
@@ -106,7 +106,7 @@ dependencies {
     // runtimeOnlyNonPublishable("com.github.GTNewHorizons:ForestryMC:4.10.5:dev")
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:neiaddons:1.16.0:dev')
     // runtimeOnlyNonPublishable('com.github.GTNewHorizons:MagicBees:2.9.2-GTNH:dev')
-    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.5.4:dev')
+    // runtimeOnlyNonPublishable('com.github.GTNewHorizons:Binnie:2.5.7:dev')
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')
@@ -119,7 +119,7 @@ dependencies {
     functionalTestImplementation('org.junit.platform:junit-platform-reporting')
 
     runtimeOnlyNonPublishable("com.github.GTNewHorizons:DuraDisplay:1.3.4:dev")
-    runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.9.6:dev')
+    runtimeOnlyNonPublishable('com.github.GTNewHorizons:EnderIO:2.9.7:dev')
 
     // For testing
     //runtimeOnlyNonPublishable('com.github.GTNewHorizons:TCNEIAdditions:1.4.2:dev')

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ modId = gregtech
 modGroup = gregtech
 
 # Whether to use modGroup as the maven publishing group.
-# Due to a history of using JitPack, the default is com.github.GTNewHorizons for all mods.
+# When false, com.github.GTNewHorizons is used.
 useModGroupForPublishing = false
 
 # Updates your build.gradle and settings.gradle automatically whenever an update is available.

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.37'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.38'
 }
 
 

--- a/src/main/java/gregtech/common/tileentities/machines/steam/MTESteamPipelessHatch.java
+++ b/src/main/java/gregtech/common/tileentities/machines/steam/MTESteamPipelessHatch.java
@@ -94,9 +94,9 @@ public class MTESteamPipelessHatch extends MTEHatchCustomFluidBase {
         if (mTier == 0) {
             // Pipeless Steam Hatch
             return new String[] {
-                GRAY               + "Stores steam globally in a network, up to 2^(2^31) L.",
+                GRAY               + "Stores Steam globally in a network, up to 2^(2^31) L.",
                 GRAY               + "Does not connect to pipes. This block withdraws Steam from the network.",
-                GRAY               + "Supports Steam, Superheated Steam and Supercritical Steam (and their dense variants).",
+                GRAY               + "Supports Steam, Superheated Steam, and Supercritical Steam (and their dense variants).",
                 GRAY               + "Capacity: " + GTUtility.formatNumbers(getCapacity()) + "L",
                 AQUA + "" + ITALIC + "Where does it come from? Capable of extracting Steam from seemingly nowhere, and even",
                 AQUA + "" + ITALIC + "without any type of Pipes, you begin to question what you thought you knew about this",
@@ -105,9 +105,9 @@ public class MTESteamPipelessHatch extends MTEHatchCustomFluidBase {
         }
         // Pipeless Jetstream Hatch
         return new String[] {
-            GRAY               + "Stores steam globally in a network, up to 2^(2^31) L.",
+            GRAY               + "Stores Steam globally in a network, up to 2^(2^31) L.",
             GRAY               + "Does not connect to pipes. This block withdraws Steam from the network.",
-            GRAY               + "Supports Steam, Superheated Steam and Supercritical Steam (and their dense variants).",
+            GRAY               + "Supports Steam, Superheated Steam, and Supercritical Steam (and their dense variants).",
             GRAY               + "Capacity: " + GTUtility.formatNumbers(getCapacity()) + "L",
             AQUA + "" + ITALIC + "Your dream recalled a 'Wireless Energy Hatch,' but you don't remember anything like the",
             AQUA + "" + ITALIC + "power of this hatch. By utilizing the immense strength of dehumidification, you've found",

--- a/src/main/java/gregtech/common/tileentities/machines/steam/MTESteamPipelessHatchOutput.java
+++ b/src/main/java/gregtech/common/tileentities/machines/steam/MTESteamPipelessHatchOutput.java
@@ -47,7 +47,7 @@ public class MTESteamPipelessHatchOutput extends MTEHatchOutput implements IFlui
             // Pipeless Steam Vent
             return new String[] {
                 GRAY               + "Stores Steam globally in a network, up to 2^(2^31) L.",
-                GRAY               + "Does not connect to Pipes. This block accepts Steam into the network.",
+                GRAY               + "Can connect to pipes to accept Steam from other sources. This block accepts Steam into the network.",
                 GRAY               + "Supports Steam, Superheated Steam, and Supercritical Steam (and their dense variants).",
                 GRAY               + "Capacity: " + GTUtility.formatNumbers(getCapacity()) + "L",
                 AQUA + "" + ITALIC + "In a dream, you remember something named a 'Wireless Energy Dynamo,' or something like",
@@ -58,7 +58,7 @@ public class MTESteamPipelessHatchOutput extends MTEHatchOutput implements IFlui
         // Pipeless Jetstream Vent
         return new String[] {
             GRAY               + "Stores Steam globally in a network, up to 2^(2^31) L.",
-            GRAY               + "Does not connect to Pipes. This block accepts Steam into the network.",
+            GRAY               + "Can connect to pipes to accept Steam from other sources. This block accepts Steam into the network.",
             GRAY               + "Supports Steam, Superheated Steam, and Supercritical Steam (and their dense variants).",
             GRAY               + "Capacity: " + GTUtility.formatNumbers(getCapacity()) + "L",
             AQUA + "" + ITALIC + "You've heard whispers of a mechanism called the 'Steamgate.' In your research, you're still unsure of",
@@ -135,6 +135,11 @@ public class MTESteamPipelessHatchOutput extends MTEHatchOutput implements IFlui
     public boolean allowPullStack(IGregTechTileEntity aBaseMetaTileEntity, int aIndex, ForgeDirection side,
         ItemStack aStack) {
         return false;
+    }
+
+    @Override
+    public boolean isLiquidInput(ForgeDirection side) {
+        return true;
     }
 
     @Override


### PR DESCRIPTION
As discussed with Four on discord.

This allows fluid pipes to connect to the Pipeless Steam Vent and insert fluids into it. This lets the player deposit steam into the pipeless network if it was generated by non-GT sources, for example RC boilers.

The hatch currently does not check whether the fluid inserted is actually steam; if you route in a wrong fluid that's just a skill issue. Only steam will be actually deposited into the network, if any other fluid enters the hatch it will simply stay there and clog it until manually removed.

Also fixes some minor spelling inconsistencies between the Pipeless Hatch and Vent.