### PR TITLE
Fix GTTeam duplication issue.

### DIFF
--- a/src/main/java/gregtech/common/misc/teams/GTTeam.java
+++ b/src/main/java/gregtech/common/misc/teams/GTTeam.java
@@ -39,7 +39,7 @@ public class GTTeam {
     }
 
     public void addMember(UUID uuid) {
-        members.add(uuid);
+        if (!members.contains(uuid)) members.add(uuid);
         TeamWorldSavedData.markForSaving();
     }
 
@@ -58,9 +58,9 @@ public class GTTeam {
     }
 
     public void addOwner(UUID uuid) {
-        owners.add(uuid);
+        if (!members.contains(uuid)) owners.add(uuid);
         // owners are also always members
-        members.add(uuid);
+        if (!members.contains(uuid)) members.add(uuid);
         TeamWorldSavedData.markForSaving();
     }
 

--- a/src/main/java/gregtech/common/misc/teams/GTTeam.java
+++ b/src/main/java/gregtech/common/misc/teams/GTTeam.java
@@ -19,8 +19,6 @@ public class GTTeam {
 
     public GTTeam(String teamName) {
         this.teamName = teamName;
-        GTTeamManager.TEAMS.add(this);
-        TeamWorldSavedData.markForSaving();
     }
 
     public String getTeamName() {

--- a/src/main/java/gregtech/common/misc/teams/GTTeamManager.java
+++ b/src/main/java/gregtech/common/misc/teams/GTTeamManager.java
@@ -37,6 +37,7 @@ public class GTTeamManager {
         GTTeam team = new GTTeam(playerName + "'s Team");
         team.initializeData(TeamDataTypes.values());
         team.addOwner(playerUuid);
+        TEAMS.add(team);
         TeamWorldSavedData.markForSaving();
         return team;
     }

--- a/src/main/java/gregtech/common/misc/teams/GTTeamManager.java
+++ b/src/main/java/gregtech/common/misc/teams/GTTeamManager.java
@@ -42,6 +42,30 @@ public class GTTeamManager {
         return team;
     }
 
+    /**
+     * Adds a team, but only if the same team (same name, same owners and same members) does not already exist.
+     *
+     * @param team Team to be added.
+     * @return True if a new team was added, false if this is a duplication of an existing team.
+     *
+     *         This fixes an issue where the same team would be saved twice to the NBT data after world reload in
+     *         singleplayer.
+     */
+    public static boolean addTeamDeduplicated(GTTeam team) {
+        for (GTTeam otherTeam : TEAMS) {
+            if (team.getTeamName()
+                .equals(otherTeam.getTeamName())
+                && team.getOwners()
+                    .equals(otherTeam.getOwners())
+                && team.getMembers()
+                    .equals(otherTeam.getMembers())) {
+                return false;
+            }
+        }
+        TEAMS.add(team);
+        return true;
+    }
+
     public static PipelessSteamManager getSteamData(GTTeam team) {
         return (PipelessSteamManager) team.getData(TeamDataTypes.PIPELESS);
     }

--- a/src/main/java/gregtech/common/misc/teams/TeamWorldSavedData.java
+++ b/src/main/java/gregtech/common/misc/teams/TeamWorldSavedData.java
@@ -80,7 +80,7 @@ public class TeamWorldSavedData extends WorldSavedData {
                 data.readFromNBT(teamData);
             }
 
-            GTTeamManager.TEAMS.add(team);
+            GTTeamManager.addTeamDeduplicated(team);
         }
     }
 

--- a/src/main/java/gregtech/common/misc/teams/TeamWorldSavedData.java
+++ b/src/main/java/gregtech/common/misc/teams/TeamWorldSavedData.java
@@ -54,6 +54,7 @@ public class TeamWorldSavedData extends WorldSavedData {
 
     @Override
     public void readFromNBT(NBTTagCompound NBT) {
+        GTTeamManager.clear();
         NBTTagList teamList = NBT.getTagList("TeamList", Constants.NBT.TAG_COMPOUND);
         for (int i = 0; i < teamList.tagCount(); i++) {
             NBTTagCompound teamTag = teamList.getCompoundTagAt(i);


### PR DESCRIPTION
Fixes an issue where instances of `GTTeam` (teams used for the purpose of sharing pipeless steam; this is not related to SU teams at all) were being repeatedly duplicated on world restart.

Discord discussion of the issue starts here: [link](https://discord.com/channels/181078474394566657/522098956491030558/1360647948320641116); eventual resolution here: [link](https://discord.com/channels/181078474394566657/522098956491030558/1360728197280432389).

The problem begins when teams are being loaded from NBT on world initialization: see [TeamWorldSavedData.readFromNBT](https://github.com/serenibyss/GT5-Unofficial/blob/20e752d38a4ecaf27dad57be3ca7d22f1799c738/src/main/java/gregtech/common/misc/teams/TeamWorldSavedData.java#L56). On line 62, a new team is created. The [constructor of `GTTeam`](https://github.com/serenibyss/GT5-Unofficial/blob/20e752d38a4ecaf27dad57be3ca7d22f1799c738/src/main/java/gregtech/common/misc/teams/GTTeam.java#L20) adds this team to the global list `GTTeamManager.TEAMS`. But then, after details of the team are read from NBT, on line 83 the team is added to this list again. This results in every team appearing in this list twice.

Subsequently, when the world is closed (or the player quits a singleplayer game), this list with duplicates is saved back to NBT. On the next world load, the list is read again, and all teams are duplicated again. This repeats, with the number of teams growing exponentially with each world restart. In my singleplayer game I ended up with over *1 million* (2^20) copies of my team; after which the game crashed on loading due to out of memory errors.

This fix removes the double addition of teams; the constructor no longer adds a team to the list, but rather a team is always added explicitly when needed. I have also added protection against duplicate players appearing in the same team, and duplicate teams being added to the global list. This means that if a player loads a save which already contains such a corrupted list of teams with duplicates, the list is deduplicated automagically, and will return to normal on next restart.

NBT data saved from a world before this fix, showing the error after reloading the world three times:

![](https://i.imgur.com/jehRAtI.png)

After loading the save with this fix applied:

![](https://i.imgur.com/iv0tKmx.png)