### PR TITLE
Fix Steel Gear Box Manufacturer recipe.

### DIFF
--- a/src/main/java/gregtech/loaders/postload/recipes/AssortedSteamRecipes.java
+++ b/src/main/java/gregtech/loaders/postload/recipes/AssortedSteamRecipes.java
@@ -844,10 +844,10 @@ public class AssortedSteamRecipes implements Runnable {
 
         RA.stdBuilder()
             .itemInputs(
-                GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Bronze, 1),
-                GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Bronze, 2),
-                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Bronze, 4))
-            .itemOutputs(ItemUtils.simpleMetaStack(GregTechAPI.sBlockCasings2, 2, 1))
+                GTOreDictUnificator.get(OrePrefixes.frameGt, Materials.Steel, 1),
+                GTOreDictUnificator.get(OrePrefixes.gearGt, Materials.Steel, 2),
+                GTOreDictUnificator.get(OrePrefixes.plate, Materials.Steel, 4))
+            .itemOutputs(ItemUtils.simpleMetaStack(GregTechAPI.sBlockCasings2, 3, 1))
             .duration(2 * SECONDS)
             .eut(16)
             .addTo(steamManufacturerRecipes);


### PR DESCRIPTION
The Manufacturer recipe for Bronze Gear Box was copy-pasted into the Steel section, but the components and output were not changed to steel ones. This resulted in two identical recipes for Bronze Gear Box, and no recipe for Steel Gear Box.

This PR fixes this error. Recipe inputs/parameters remain unchanged.